### PR TITLE
Add clickable static URDF control

### DIFF
--- a/frontend/src/components/files/DragControl.tsx
+++ b/frontend/src/components/files/DragControl.tsx
@@ -1,0 +1,312 @@
+import {
+  Camera,
+  Object3D,
+  Plane,
+  Ray,
+  Raycaster,
+  Scene,
+  Vector2,
+  Vector3,
+} from "three";
+import { URDFJoint } from "urdf-loader";
+
+export function isJoint(o: unknown): boolean {
+  const j = o as URDFJoint;
+  return j && j.isURDFJoint && j.jointType !== "fixed";
+}
+
+function findNearestJoint(child: Object3D): URDFJoint | null {
+  let curr: Object3D | null = child;
+  while (curr) {
+    if (isJoint(curr)) {
+      return curr as URDFJoint;
+    }
+    curr = curr.parent;
+  }
+  return null;
+}
+
+export class URDFDragControls {
+  enabled: boolean;
+  scene: Scene;
+  raycaster: Raycaster;
+  initialGrabPoint: Vector3;
+  hitDistance: number;
+  hovered: URDFJoint | null;
+  manipulating: URDFJoint | null;
+
+  // Add the variables as private properties
+  protected prevHitPoint: Vector3;
+  protected newHitPoint: Vector3;
+  protected pivotPoint: Vector3;
+  protected tempVector: Vector3;
+  protected tempVector2: Vector3;
+  protected projectedStartPoint: Vector3;
+  protected projectedEndPoint: Vector3;
+  protected plane: Plane;
+
+  protected draggable: boolean;
+
+  constructor(scene: Scene, draggable = false) {
+    this.enabled = true;
+    this.scene = scene;
+    this.raycaster = new Raycaster();
+    this.initialGrabPoint = new Vector3();
+
+    this.hitDistance = -1;
+    this.hovered = null;
+    this.manipulating = null;
+
+    // Initialize the private variables
+    this.prevHitPoint = new Vector3();
+    this.newHitPoint = new Vector3();
+    this.pivotPoint = new Vector3();
+    this.tempVector = new Vector3();
+    this.tempVector2 = new Vector3();
+    this.projectedStartPoint = new Vector3();
+    this.projectedEndPoint = new Vector3();
+    this.plane = new Plane();
+
+    this.draggable = draggable;
+  }
+
+  update() {
+    const { raycaster, hovered, manipulating, scene } = this;
+
+    if (manipulating) {
+      return;
+    }
+
+    scene.updateMatrixWorld();
+
+    let hoveredJoint: URDFJoint | null = null;
+    const intersections = raycaster.intersectObjects(scene.children, true);
+    if (intersections.length !== 0) {
+      const hit = intersections[0];
+      this.hitDistance = hit.distance;
+      hoveredJoint = findNearestJoint(hit.object);
+      if (hoveredJoint) {
+        this.initialGrabPoint.copy(hit.point);
+      }
+    }
+
+    if (hoveredJoint !== hovered) {
+      if (hovered) {
+        this.onUnhover(hovered);
+      }
+      this.hovered = hoveredJoint;
+      if (hoveredJoint) {
+        this.onHover(hoveredJoint);
+      }
+    }
+  }
+
+  updateJoint(joint: URDFJoint, angle: number) {
+    joint.setJointValue(angle);
+  }
+
+  onDragStart(joint: URDFJoint) {}
+
+  onDragEnd(joint: URDFJoint) {}
+
+  onHover(joint: URDFJoint) {}
+
+  onUnhover(joint: URDFJoint) {}
+
+  onClick(joint: URDFJoint) {}
+
+  getRevoluteDelta(
+    joint: URDFJoint,
+    startPoint: Vector3,
+    endPoint: Vector3,
+  ): number {
+    // set up the plane
+    this.tempVector
+      .copy(joint.axis)
+      .transformDirection(joint.matrixWorld)
+      .normalize();
+    this.pivotPoint.set(0, 0, 0).applyMatrix4(joint.matrixWorld);
+    this.plane.setFromNormalAndCoplanarPoint(this.tempVector, this.pivotPoint);
+
+    // project the drag points onto the plane
+    this.plane.projectPoint(startPoint, this.projectedStartPoint);
+    this.plane.projectPoint(endPoint, this.projectedEndPoint);
+
+    // get the directions relative to the pivot
+    this.projectedStartPoint.sub(this.pivotPoint);
+    this.projectedEndPoint.sub(this.pivotPoint);
+
+    this.tempVector.crossVectors(
+      this.projectedStartPoint,
+      this.projectedEndPoint,
+    );
+
+    const direction = Math.sign(this.tempVector.dot(this.plane.normal));
+    return direction * this.projectedEndPoint.angleTo(this.projectedStartPoint);
+  }
+
+  getPrismaticDelta(
+    joint: URDFJoint,
+    startPoint: Vector3,
+    endPoint: Vector3,
+  ): number {
+    this.tempVector.subVectors(endPoint, startPoint);
+    this.plane.normal
+      .copy(joint.axis)
+      .transformDirection(joint.parent!.matrixWorld)
+      .normalize();
+
+    return this.tempVector.dot(this.plane.normal);
+  }
+
+  moveRay(toRay: Ray) {
+    const { raycaster, hitDistance, manipulating } = this;
+    const { ray } = raycaster;
+
+    if (manipulating && this.draggable) {
+      ray.at(hitDistance, this.prevHitPoint);
+      toRay.at(hitDistance, this.newHitPoint);
+
+      let delta = 0;
+      if (
+        manipulating.jointType === "revolute" ||
+        manipulating.jointType === "continuous"
+      ) {
+        delta = this.getRevoluteDelta(
+          manipulating,
+          this.prevHitPoint,
+          this.newHitPoint,
+        );
+      } else if (manipulating.jointType === "prismatic") {
+        delta = this.getPrismaticDelta(
+          manipulating,
+          this.prevHitPoint,
+          this.newHitPoint,
+        );
+      }
+
+      if (delta) {
+        this.updateJoint(manipulating, manipulating.angle.valueOf() + delta);
+      }
+    }
+
+    this.raycaster.ray.copy(toRay);
+    this.update();
+  }
+
+  setGrabbed(grabbed: boolean) {
+    const { hovered, manipulating } = this;
+
+    if (grabbed) {
+      if (manipulating !== null || hovered === null) {
+        return;
+      }
+
+      this.manipulating = hovered;
+      this.onDragStart(hovered);
+    } else {
+      if (this.manipulating === null) {
+        return;
+      }
+
+      this.onDragEnd(this.manipulating);
+      const manipulating = this.manipulating;
+      this.manipulating = null;
+      this.update();
+      if (manipulating == this.hovered) {
+        this.onClick(manipulating!);
+      }
+    }
+  }
+}
+
+export class PointerURDFDragControls extends URDFDragControls {
+  camera: Camera;
+  domElement: HTMLElement;
+
+  private _mouseDown: (e: MouseEvent) => void;
+  private _mouseMove: (e: MouseEvent) => void;
+  private _mouseUp: (e: MouseEvent) => void;
+
+  constructor(scene: Scene, camera: Camera, domElement: HTMLElement) {
+    super(scene);
+    this.camera = camera;
+    this.domElement = domElement;
+
+    const raycaster = new Raycaster();
+    const mouse = new Vector2();
+
+    const updateMouse = (e: MouseEvent) => {
+      const rect = domElement.getBoundingClientRect();
+      mouse.x = ((e.clientX - rect.x) / rect.width) * 2 - 1;
+      mouse.y = -((e.clientY - rect.y) / rect.height) * 2 + 1;
+    };
+
+    this._mouseDown = (e: MouseEvent) => {
+      updateMouse(e);
+      raycaster.setFromCamera(mouse, this.camera);
+      this.moveRay(raycaster.ray);
+      this.setGrabbed(true);
+    };
+
+    this._mouseMove = (e: MouseEvent) => {
+      updateMouse(e);
+      raycaster.setFromCamera(mouse, this.camera);
+      this.moveRay(raycaster.ray);
+    };
+
+    this._mouseUp = (e: MouseEvent) => {
+      updateMouse(e);
+      raycaster.setFromCamera(mouse, this.camera);
+      this.moveRay(raycaster.ray);
+      this.setGrabbed(false);
+    };
+
+    domElement.addEventListener("mousedown", this._mouseDown);
+    domElement.addEventListener("mousemove", this._mouseMove);
+    domElement.addEventListener("mouseup", this._mouseUp);
+  }
+
+  getRevoluteDelta(
+    joint: URDFJoint,
+    startPoint: Vector3,
+    endPoint: Vector3,
+  ): number {
+    const { camera, initialGrabPoint } = this;
+
+    // set up the plane
+    this.tempVector
+      .copy(joint.axis)
+      .transformDirection(joint.matrixWorld)
+      .normalize();
+    this.pivotPoint.set(0, 0, 0).applyMatrix4(joint.matrixWorld);
+    this.plane.setFromNormalAndCoplanarPoint(this.tempVector, this.pivotPoint);
+
+    this.tempVector.copy(camera.position).sub(initialGrabPoint).normalize();
+
+    // if looking into the plane of rotation
+    if (Math.abs(this.tempVector.dot(this.plane.normal)) > 0.3) {
+      return super.getRevoluteDelta(joint, startPoint, endPoint);
+    } else {
+      // get the up direction
+      this.tempVector.set(0, 1, 0).transformDirection(camera.matrixWorld);
+
+      // get points projected onto the plane of rotation
+      this.plane.projectPoint(startPoint, this.projectedStartPoint);
+      this.plane.projectPoint(endPoint, this.projectedEndPoint);
+
+      this.tempVector.set(0, 0, -1).transformDirection(camera.matrixWorld);
+      this.tempVector.cross(this.plane.normal);
+      this.tempVector2.subVectors(endPoint, startPoint);
+
+      return this.tempVector.dot(this.tempVector2);
+    }
+  }
+
+  dispose() {
+    const { domElement } = this;
+    domElement.removeEventListener("mousedown", this._mouseDown);
+    domElement.removeEventListener("mousemove", this._mouseMove);
+    domElement.removeEventListener("mouseup", this._mouseUp);
+  }
+}

--- a/frontend/src/components/files/StaticURDFRenderer.tsx
+++ b/frontend/src/components/files/StaticURDFRenderer.tsx
@@ -1,0 +1,280 @@
+import React, { useEffect, useRef, } from "react";
+import * as THREE from "three";
+import { Material } from "three";
+import { STLLoader } from "three/examples/jsm/loaders/STLLoader";
+import URDFLoader, { URDFJoint, URDFLink, URDFRobot } from "urdf-loader";
+import { PointerURDFDragControls, isJoint } from "./DragControl";
+import { UntarredFile } from "./untar";
+
+interface JointControl {
+  name: string;
+  min: number;
+  max: number;
+  value: number;
+}
+
+type Orientation = "Z-up" | "Y-up" | "X-up";
+
+const URDFRenderer: React.FC<{
+  urdfContent: string;
+  files: UntarredFile[];
+  onJointClicked: (a: URDFJoint) => void;
+}> = ({ urdfContent, files, onJointClicked }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sceneRef = useRef<THREE.Scene | null>(null);
+  const worldRef = useRef<THREE.Object3D | null>(null);
+  const robotRef = useRef<THREE.Object3D | null>(null);
+  const animationRef = useRef<number | null>(null);
+  const dragControlsRef = useRef<PointerURDFDragControls | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const scene = new THREE.Scene();
+    sceneRef.current = scene;
+    scene.background = new THREE.Color(0xffffff);
+
+    const world = new THREE.Object3D();
+    worldRef.current = world;
+    scene.add(world);
+
+    const camera = new THREE.PerspectiveCamera(
+      50,
+      containerRef.current.clientWidth / containerRef.current.clientHeight,
+      0.1,
+      1000,
+    );
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(
+      containerRef.current.clientWidth,
+      containerRef.current.clientHeight,
+    );
+    containerRef.current.appendChild(renderer.domElement);
+
+    // Lighting setup
+    const frontLight = new THREE.DirectionalLight(0xffffff, 0.7);
+    frontLight.position.set(1, 1, 1);
+    scene.add(frontLight);
+
+    const backLight = new THREE.DirectionalLight(0xffffff, 0.3);
+    backLight.position.set(-1, -1, -1);
+    scene.add(backLight);
+
+    const ambientLight = new THREE.AmbientLight(0x404040, 0.5);
+    scene.add(ambientLight);
+
+    const loader = new URDFLoader();
+    loader.loadMeshCb = (path, _manager, onComplete) => {
+      const fileContent = files.find((f) => f.name.endsWith(path))?.content;
+      if (fileContent) {
+        const geometry = new STLLoader().parse(fileContent.buffer);
+        const material = new THREE.MeshPhongMaterial({
+          color: 0xffffff,
+          side: THREE.DoubleSide,
+        });
+        const mesh = new THREE.Mesh(geometry, material);
+        onComplete(mesh);
+      } else {
+        onComplete(new THREE.Object3D());
+      }
+    };
+
+    const robot = loader.parse(urdfContent);
+    robotRef.current = robot;
+    world.add(robot);
+
+    // Center and scale the robot
+    const box = new THREE.Box3().setFromObject(robot);
+    const center = box.getCenter(new THREE.Vector3());
+    const size = box.getSize(new THREE.Vector3());
+    const maxDim = Math.max(size.x, size.y, size.z);
+    const scale = 5 / maxDim;
+    robot.scale.multiplyScalar(scale);
+    robot.position.sub(center.multiplyScalar(scale));
+
+    // Position camera in front of the robot
+    const distance = 10;
+    camera.position.set(0, distance / 4, -distance);
+    camera.lookAt(new THREE.Vector3(0, 0, 0));
+    // controls.update();
+
+    // Collect joint information
+    const joints: JointControl[] = [];
+    robot.traverse((child) => {
+      if ("isURDFJoint" in child && child.isURDFJoint) {
+        const joint = child as URDFJoint;
+        const initialValue =
+          (Number(joint.limit.lower) + Number(joint.limit.upper)) / 2;
+        joints.push({
+          name: joint.name,
+          min: Number(joint.limit.lower),
+          max: Number(joint.limit.upper),
+          value: initialValue,
+        });
+        joint.setJointValue(initialValue);
+      }
+    });
+    // Sort joints alphabetically by name
+    joints.sort((a, b) => a.name.localeCompare(b.name));
+
+    // Collect link information.
+    const links: URDFLink[] = [];
+    robot.traverse((child) => {
+      if ("isURDFLink" in child && child.isURDFLink) {
+        const link = child as URDFLink;
+        links.push(link);
+      }
+    });
+
+    const animate = () => {
+      requestAnimationFrame(animate);
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    const handleResize = () => {
+      if (!containerRef.current) return;
+      camera.aspect = containerRef.current.clientWidth /
+        containerRef.current.clientHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(
+        containerRef.current.clientWidth,
+        containerRef.current.clientHeight,
+      );
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    const updateOrientation = (newOrientation: Orientation) => {
+      if (robotRef.current) {
+        const robot = robotRef.current;
+
+        // Reset rotations
+        robot.rotation.set(0, 0, 0);
+
+        switch (newOrientation) {
+          case "Y-up":
+            robot.rotateX(-Math.PI / 2);
+            break;
+          case "X-up":
+            robot.rotateZ(Math.PI / 2);
+            break;
+            // 'Z-up' is the default, no rotation needed
+        }
+        robot.updateMatrixWorld();
+      }
+    };
+
+    updateOrientation("Z-up");
+    const updateMaterials = (mesh: URDFRobot) => {
+      mesh.traverse((child:any) => {
+        const c = child as THREE.Mesh;
+        if (c.isMesh) {
+          c.castShadow = true;
+          c.receiveShadow = true;
+
+          if (c.material) {
+            const mats = (Array.isArray(c.material) ? c.material : [c.material])
+              .map((mesh:Material) => {
+                if (mesh instanceof THREE.MeshBasicMaterial) {
+                  mesh = new THREE.MeshPhongMaterial();
+                }
+
+                const m = mesh as THREE.MeshPhongMaterial;
+                if (m.map) {
+                  m.map.colorSpace = THREE.SRGBColorSpace;
+                }
+
+                return m;
+              });
+            c.material = mats.length === 1 ? mats[0] : mats;
+          }
+        }
+      });
+    };
+    updateMaterials(robot);
+
+    const highlightMaterial = new THREE.MeshPhongMaterial({
+      shininess: 10,
+      color: 0xffffff,
+      emissive: 0xffffff,
+      emissiveIntensity: 0.25,
+    });
+
+    const highlightLinkGeometry = (m:THREE.Object3D, revert: boolean) => {
+      const traverse = (c: any) => {
+        // Set or revert the highlight color
+        if (c.type === "Mesh") {
+          if (revert) {
+            c.material = c.__origMaterial;
+            delete c.__origMaterial;
+          } else {
+            c.__origMaterial = c.material;
+            c.material = highlightMaterial;
+          }
+        }
+
+        // Look into the children and stop if the next child is
+        // another joint
+        if (c === m || !isJoint(c)) {
+          for (let i = 0; i < c.children.length; i++) {
+            const child = c.children[i];
+            if (!child.isURDFCollider) {
+              traverse(c.children[i]);
+            }
+          }
+        }
+      };
+      traverse(m);
+    };
+
+    animate();
+    world.updateMatrixWorld(true);
+    const dragControls = new PointerURDFDragControls(
+      scene,
+      camera,
+      renderer.domElement,
+    );
+    dragControlsRef.current = dragControls;
+    dragControls.onHover = (joint) => {
+      highlightLinkGeometry(joint, false);
+      renderer.render(scene, camera);
+    };
+    dragControls.onUnhover = (joint) => {
+      highlightLinkGeometry(joint, true);
+      renderer.render(scene, camera);
+    };
+    dragControls.onClick = onJointClicked;
+
+    return () => {
+      if (containerRef.current) {
+        containerRef.current.removeChild(renderer.domElement);
+      }
+      window.removeEventListener("resize", handleResize);
+      updateOrientation("Z-up"); // Reset orientation on unmount
+    };
+  }, [urdfContent, files]);
+
+  // Ensure that callbacks are updated as component is rerendered.
+  useEffect(()=> {
+    if (dragControlsRef.current !== null) {
+      dragControlsRef.current!.onClick = onJointClicked
+    }
+  }, [onJointClicked])
+
+  useEffect(() => {
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="flex flex-col lg:flex-row h-full relative">
+      <div ref={containerRef} className="flex-grow h-[60vh] lg:h-auto" />
+    </div>
+  );
+};
+
+export default URDFRenderer;


### PR DESCRIPTION
This control is a static URDF renderer and allows users to click on certain elements of the robot. In the future we can refactor this so it can be shared between the full URDF control element.

It also highlights currently hovered components.