### PR TITLE
add nn and soft torque limit

### DIFF
--- a/www/crud/robot_class.py
+++ b/www/crud/robot_class.py
@@ -22,6 +22,8 @@ class JointMetadata(BaseModel):
     offset: Decimal | None = None
     flipped: bool | None = None
     actuator_type: str | None = None
+    nn_id: int | None = None
+    soft_torque_limit: Decimal | None = None
 
 
 class RobotURDFMetadata(BaseModel):


### PR DESCRIPTION
**What does this PR do?**

Adds the `nn_id` and `soft_torque_limit` fields to `JointMetadataOutput`

**What issues does this PR fix or reference?**

Allows us to have a single source of truth for deployment and training
