### PR TITLE
add actuator metadata, needed for zbot

### DIFF
--- a/www/crud/robot_class.py
+++ b/www/crud/robot_class.py
@@ -28,6 +28,7 @@ class JointMetadata(BaseModel):
 
 class ActuatorMetadata(BaseModel):
     """Defines the metadata for an actuator."""
+
     actuator_type: str | None = None
     sysid: str | None = None
     max_torque: Decimal | None = None

--- a/www/crud/robot_class.py
+++ b/www/crud/robot_class.py
@@ -26,8 +26,27 @@ class JointMetadata(BaseModel):
     soft_torque_limit: Decimal | None = None
 
 
+class ActuatorMetadata(BaseModel):
+    """Defines the metadata for an actuator."""
+    actuator_type: str | None = None
+    sysid: str | None = None
+    max_torque: Decimal | None = None
+    armature: Decimal | None = None
+    damping: Decimal | None = None
+    frictionloss: Decimal | None = None
+    vin: Decimal | None = None
+    kt: Decimal | None = None
+    R: Decimal | None = None
+    vmax: Decimal | None = None
+    amax: Decimal | None = None
+    max_velocity: Decimal | None = None
+    max_pwm: Decimal | None = None
+    error_gain: Decimal | None = None
+
+
 class RobotURDFMetadata(BaseModel):
     joint_name_to_metadata: dict[str, JointMetadata] | None = None
+    actuator_type_to_metadata: dict[str, ActuatorMetadata] | None = None
     control_frequency: Decimal | None = None
 
 
@@ -66,6 +85,8 @@ class RobotClassCrud(DBCrud):
         if metadata is None:
             return True
         if metadata.joint_name_to_metadata is not None and len(metadata.joint_name_to_metadata) > 1000:
+            return False
+        if metadata.actuator_type_to_metadata is not None and len(metadata.actuator_type_to_metadata) > 1000:
             return False
         return True
 


### PR DESCRIPTION
**What does this PR do?**

Adds an actuator metadata class 

**What issues does this PR fix or reference?**

Zbot's feetech stateful actuators require this metadata. See https://github.com/kscalelabs/kscale-assets/blob/master/actuators/feetech_sts3250.json

**If this PR changes the UI, include a screenshot below.**

It does not change the ui